### PR TITLE
Allowing routes path to be configurable

### DIFF
--- a/src/Commands/Crud.php
+++ b/src/Commands/Crud.php
@@ -80,7 +80,12 @@ class Crud extends Command
     public function generateRoute()
     {
         $route = "Route::resource('{$this->route()}','{$this->controllerClassName()}');";
-        $routesFile = app_path('Http/routes.php');
+        $routesFile = app_path(config('crud.routesFile'));
+        if ( !file_exists($routesFile))
+        {
+            $this->error("Route file '$routesFile' not found. Update config/crud.php to correct path.");
+            return false;
+        }
         $routesFileContent = file_get_contents($routesFile);
 
         if ( strpos( $routesFileContent, $route ) == false )

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -20,6 +20,11 @@ $config = [
      * */
     'templates' => 'vendor.crud.single-page-templates',
 
+    /*
+     * Define the path to the routes file. This changed in recent
+     * versions of Laravel. Set to 'Http/routes.php' for Laravel < 5.4
+     * */
+    'routesFile' => '../routes/web.php',
 ];
 
     /*


### PR DESCRIPTION
I have made a pull request that allows the developer to define in the configuration where the routes file should be. This is because the routes filename and path have changed in recent versions. The new config defaults to Laravel version 5.4